### PR TITLE
Update SafetyRoll.lua Fixes missing sound when falling on hands in singleplayer

### DIFF
--- a/beatrun/gamemodes/beatrun/gamemode/sh/SafetyRoll.lua
+++ b/beatrun/gamemodes/beatrun/gamemode/sh/SafetyRoll.lua
@@ -91,7 +91,7 @@ hook.Add("SetupMove", "EvadeRoll", function(ply, mv, cmd)
 		if SERVER and not land then
 			ply:EmitSound("Cloth.Roll")
 			ply:EmitSound("Cloth.RollLand")
-		elseif CLIENT_IFTP() then
+		elseif true then
 			ply:EmitSound("Handsteps.ConcreteHard")
 			ply:EmitSound("Land.Concrete")
 		end
@@ -155,7 +155,7 @@ hook.Add("OnPlayerHitGround", "SafetyRoll", function(ply, water, floater, speed)
 		if SERVER and not land then
 			ply:EmitSound("Cloth.Roll")
 			ply:EmitSound("Cloth.RollLand")
-		elseif CLIENT_IFTP() then
+		elseif true then
 			ply:EmitSound("Handsteps.ConcreteHard")
 			ply:EmitSound("Land.Concrete")
 		end

--- a/beatrun/gamemodes/beatrun/gamemode/sh/SafetyRoll.lua
+++ b/beatrun/gamemodes/beatrun/gamemode/sh/SafetyRoll.lua
@@ -91,7 +91,7 @@ hook.Add("SetupMove", "EvadeRoll", function(ply, mv, cmd)
 		if SERVER and not land then
 			ply:EmitSound("Cloth.Roll")
 			ply:EmitSound("Cloth.RollLand")
-		elseif true then
+		elseif CLIENT_IFTP() or game.SinglePlayer() then
 			ply:EmitSound("Handsteps.ConcreteHard")
 			ply:EmitSound("Land.Concrete")
 		end
@@ -155,7 +155,7 @@ hook.Add("OnPlayerHitGround", "SafetyRoll", function(ply, water, floater, speed)
 		if SERVER and not land then
 			ply:EmitSound("Cloth.Roll")
 			ply:EmitSound("Cloth.RollLand")
-		elseif true then
+		elseif CLIENT_IFTP() or game.SinglePlayer() then
 			ply:EmitSound("Handsteps.ConcreteHard")
 			ply:EmitSound("Land.Concrete")
 		end


### PR DESCRIPTION
Fixes sound when falling on hands in singleplayer.
For some reason CLIENT_IFTP() was preventing to play these sounds in singleplayer. 
This will ensure that the sounds are played regardless of whether it's a singleplayer or multiplayer.