### PR TITLE
Fixing codebase links in readme files

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Infamous parkour addon for Garry's Mod, fully open sourced and maintained by the
 > * Custom Courses Database.
 >
 > **All of this is optional and you can remove all of it.**\
-> Modules are located [here](lua/bin/) and courses database functionality is [here](beatrun/gamemodes/beatrun/gamemode/cl/CoursesDatabase.lua).\
+> Modules are located [here](https://github.com/JonnyBro/beatrun/tree/main/lua/bin) and courses database functionality is [here](https://github.com/JonnyBro/beatrun/blob/main/beatrun/gamemodes/beatrun/gamemode/cl/CoursesDatabase.lua).\
 > You can find source code for modules in [Credits](#credits) section.
 
 **PLEASE READ EVERYTHING BEFORE ASKING QUESTIONS ON OUR SERVER!**

--- a/README_ru.md
+++ b/README_ru.md
@@ -12,7 +12,7 @@
 > * Пользовательская онлайн база курсов.
 >
 > **Всё это необязательно и может быть удалено.**\
-> Модули находятся [тут](lua/bin/) и функционал онлайн базы курсов доступен [здесь](beatrun/gamemodes/beatrun/gamemode/cl/CoursesDatabase.lua).\
+> Модули находятся [тут](https://github.com/JonnyBro/beatrun/tree/main/lua/bin) и функционал онлайн базы курсов доступен [здесь](https://github.com/JonnyBro/beatrun/blob/main/beatrun/gamemodes/beatrun/gamemode/cl/CoursesDatabase.lua).\
 > Исходный код модулей можно найти в [благодарностях](#благодарности).
 
 **ПОЖАЛУЙСТА, ПРОЧТИТЕ ВЕСЬ ДОКУМЕНТ ПЕРЕД ТЕМ КАК ЗАДАВАТЬ ВОПРОСЫ НА НАШЕМ СЕРВЕРЕ!**


### PR DESCRIPTION
Just fixing 2 of the links, when you click on them it doesn't take you to the files:
![image](https://github.com/JonnyBro/beatrun/assets/51441497/54503925-18f8-4164-8ae5-b644f2a0ef8e)
They redirect to invalid pages, I just pointed them to the correct files/urls in your github.