### PR TITLE
Fix FOV behavior for actual this time around

### DIFF
--- a/beatrun/gamemodes/beatrun/gamemode/player_class/player_beatrun.lua
+++ b/beatrun/gamemodes/beatrun/gamemode/player_class/player_beatrun.lua
@@ -378,20 +378,24 @@ function PLAYER:CalcView(view)
 
 		local fov = GetConVar("Beatrun_FOV"):GetInt()
 
-		if lframeswepclass != LocalPlayer():GetActiveWeapon():GetClass() then
-			-- SP clientside weapon swap detection
-			FOVModifierBlock = true
-			timer.Simple(1, function() FOVModifierBlock = false end)
-		end
+		if IsValid(LocalPlayer():GetActiveWeapon()) then
+			if lframeswepclass != LocalPlayer():GetActiveWeapon():GetClass() then
+				-- SP clientside weapon swap detection
+				FOVModifierBlock = true
+				timer.Simple(1, function() FOVModifierBlock = false end)
+			end
 
-		if !FOVModifierBlock and !LocalPlayer():GetActiveWeapon().ARC9 then
-			fixfovmult = view.fov / fov
+			if !FOVModifierBlock and !LocalPlayer():GetActiveWeapon().ARC9 then
+				fixfovmult = view.fov / fov
+			else
+				fixfovmult = 1
+			end
+
+			view.fov = fov * mult * fixfovmult
+			lframeswepclass = LocalPlayer():GetActiveWeapon():GetClass()
 		else
-			fixfovmult = 1
+			view.fov = fov * mult
 		end
-
-		view.fov = GetConVar("Beatrun_FOV"):GetInt() * mult * fixfovmult
-		lframeswepclass = LocalPlayer():GetActiveWeapon():GetClass()
 	end
 
 	if self.TauntCam:CalcView(view, self.Player, self.Player:IsPlayingTaunt()) then return true end

--- a/beatrun/gamemodes/beatrun/gamemode/player_class/player_beatrun.lua
+++ b/beatrun/gamemodes/beatrun/gamemode/player_class/player_beatrun.lua
@@ -561,8 +561,6 @@ end)
 hook.Add("PlayerSwitchWeapon", "BeatrunSwitchFOVFix", function(ply)
 	-- This ENTIRE hook is for dealing with ARC9's stupid FOV reset
 	-- behavior after switching away from an ARC9 SWEP.
-
-	-- Yes this is hacky as hell.
 	ply:SetFOV(ply:GetInfoNum("Beatrun_FOV", 120))
 	timer.Simple(0, function()
 		ply:SetFOV(ply:GetInfoNum("Beatrun_FOV", 120))
@@ -570,7 +568,6 @@ hook.Add("PlayerSwitchWeapon", "BeatrunSwitchFOVFix", function(ply)
 end)
 
 cvars.AddChangeCallback("Beatrun_FOV", function(convar, oldval, newval)
-	-- Live FOV change in SP, needs work for MP
 	if CLIENT and game.SinglePlayer() then
 		LocalPlayer():SetFOV(newval)
 	elseif CLIENT then

--- a/beatrun/gamemodes/beatrun/gamemode/player_class/player_beatrun.lua
+++ b/beatrun/gamemodes/beatrun/gamemode/player_class/player_beatrun.lua
@@ -8,10 +8,6 @@ if CLIENT then
 	CreateConVar("cl_playerskin", "0", {FCVAR_ARCHIVE, FCVAR_USERINFO, FCVAR_DONTRECORD}, "The skin to use, if the model has any")
 	CreateConVar("cl_playerbodygroups", "0", {FCVAR_ARCHIVE, FCVAR_USERINFO, FCVAR_DONTRECORD}, "The bodygroups to use, if the model has any")
 
-	--CreateConVar("Beatrun_Debug_FOVFix", 0, {FCVAR_DONTRECORD, FCVAR_UNREGISTERED, FCVAR_USERINFO}, "DEBUG: Toggles the FOV fix on or off.", 0, 1)
-	CreateClientConVar("Beatrun_Debug_FOVFix", 1, false, true, "debugging", 0, 1)
-	-- Don't record this CVar's value. Don't want players wondering how they broke FOV behavior even after restarting GMod.
-
 	local lframeswepclass = lframeswepclass or ""
 end
 

--- a/beatrun/gamemodes/beatrun/gamemode/sh/Checkpoints.lua
+++ b/beatrun/gamemodes/beatrun/gamemode/sh/Checkpoints.lua
@@ -236,6 +236,7 @@ function CourseHUD()
 	if incourse then
 		local text = string.FormattedTime(totaltime, "%02i:%02i:%02i")
 		local w, _ = surface.GetTextSize(text)
+		surface.SetFont("BeatrunHUD")
 		surface.SetTextPos(ScrW() * 0.85 - w * 0.5 + vpx, ScrH() * 0.075 + vpz)
 		surface.DrawText(text)
 	end
@@ -265,6 +266,7 @@ function CourseHUD()
 		local text = string.FormattedTime(pbtotal, "%02i:%02i:%02i")
 		local w, h = surface.GetTextSize(text)
 
+		surface.SetFont("BeatrunHUD")
 		surface.SetTextPos(ScrW() * 0.85 - w * 0.5 + vpx, ScrH() * 0.075 + h + vpz)
 		surface.SetTextColor(255, 255, 255, 125)
 		surface.DrawText(text)
@@ -277,6 +279,7 @@ function CourseHUD()
 		timealpha = math.max(0, timealpha - FrameTime() * 250)
 		timecolor.a = math.min(255, timealpha)
 
+		surface.SetFont("BeatrunHUD")
 		surface.SetTextPos(ScrW() * 0.5 - w * 0.5 + vpx, ScrH() * 0.3 + vpz)
 		surface.SetTextColor(timecolor)
 		surface.DrawText(timetext)


### PR DESCRIPTION
Fixes #179. I think. (I lost hours of sleep over this, let's hope it does.)

*"Fixes"* FOV *specifically* after switching weapons by forcing FOV value to whatever `Beatrun_FOV` is set to for .8 seconds, pretty much.

***Please** test this carefully before merging. This wasn't thoroughly tested yet (just in 2 player multiplayer in P2P).*

*(Also includes a "fix" for the timer HUD in courses looking weird in some cases (bad addons) that I can't exclude because GitHub.)*

*It is **literally 12AM** as I make this PR, please excuse some of the language and also bad coding.*

(Breaks HL2 crossbow zoom for ~1 second after switching to it, but I don't know how to fix that.)