### PR TITLE
Build mode Y rotation and remove version text in the corner

### DIFF
--- a/beatrun/gamemodes/beatrun/gamemode/sh/BuildMode.lua
+++ b/beatrun/gamemodes/beatrun/gamemode/sh/BuildMode.lua
@@ -1081,6 +1081,20 @@ if CLIENT then
 
 			LocalPlayer():EmitSound("buttonrollover.wav")
 		end,
+		[KEY_H] = function()
+			local mult = input.IsKeyDown(KEY_LCONTROL) and 0.06666666666666667 or 1
+
+			BuildModeAngle:RotateAroundAxis(Vector(0, 0, 1), 15 * mult)
+
+			LocalPlayer():EmitSound("buttonrollover.wav")
+		end,
+		[KEY_J] = function()
+			local mult = input.IsKeyDown(KEY_LCONTROL) and 0.06666666666666667 or 1
+
+			BuildModeAngle:RotateAroundAxis(Vector(0, 0, 1), -15 * mult)
+
+			LocalPlayer():EmitSound("buttonrollover.wav")
+		end,
 		[KEY_F] = function()
 			if CurTime() < BuildModePlaceDelay then return end
 

--- a/beatrun/gamemodes/beatrun/gamemode/sh/BuildMode.lua
+++ b/beatrun/gamemodes/beatrun/gamemode/sh/BuildMode.lua
@@ -1081,14 +1081,14 @@ if CLIENT then
 
 			LocalPlayer():EmitSound("buttonrollover.wav")
 		end,
-		[KEY_H] = function()
+		[KEY_N] = function()
 			local mult = input.IsKeyDown(KEY_LCONTROL) and 0.06666666666666667 or 1
 
 			BuildModeAngle:RotateAroundAxis(Vector(0, 0, 1), 15 * mult)
 
 			LocalPlayer():EmitSound("buttonrollover.wav")
 		end,
-		[KEY_J] = function()
+		[KEY_M] = function()
 			local mult = input.IsKeyDown(KEY_LCONTROL) and 0.06666666666666667 or 1
 
 			BuildModeAngle:RotateAroundAxis(Vector(0, 0, 1), -15 * mult)

--- a/beatrun/gamemodes/beatrun/gamemode/shared.lua
+++ b/beatrun/gamemodes/beatrun/gamemode/shared.lua
@@ -1,4 +1,5 @@
-VERSIONGLOBAL = "v1.0.1"
+--has anyone even seen this text?
+VERSIONGLOBAL = ""
 
 DeriveGamemode("sandbox")
 


### PR DESCRIPTION
1. datae didn't even add Y rotation in build mode so i made it myself
Rotate with "N" and "M" buttons

2. I have removed the version text that has not been changed since the beatrun release