### PR TITLE
Fix runnerhands unable to use "Last Weapon used" keybind

### DIFF
--- a/beatrun/gamemodes/beatrun/entities/weapons/runnerhands/shared.lua
+++ b/beatrun/gamemodes/beatrun/entities/weapons/runnerhands/shared.lua
@@ -99,6 +99,8 @@ function SWEP:Deploy()
 	self:SetWasOnGround(false)
 	self:SetBlockAnims(false)
 	self:SetPunch(1)
+
+	return true
 end
 
 function SWEP:Initialize()


### PR DESCRIPTION
This addresses/fixes issue #202. `SWEP:Deploy()` returns a boolean value which allows the weapon to be switched away from using the `lastinv` command.

https://wiki.facepunch.com/gmod/WEAPON:Deploy

Tested x86_64: :heavy_check_mark: 
Tested x86: :heavy_check_mark: 