### PR TITLE
Catalyst coil jump animation toggle

### DIFF
--- a/gamemodes/beatrun/content/resource/localization/en/beatrun.properties
+++ b/gamemodes/beatrun/content/resource/localization/en/beatrun.properties
@@ -158,6 +158,9 @@ beatrun.toolsmenu.gameplay.animset=Animations Set
 beatrun.toolsmenu.gameplay.animset1=Reanimated (by MTB)
 beatrun.toolsmenu.gameplay.animset2=Original (made by datae, fixed by MTB)
 
+beatrun.toolsmenu.gameplay.catalystcoil=Catalyst coil jump animation
+beatrun.toolsmenu.gameplay.catalystcoildesc=Can only be used when runnerhands is equipped, and will instead use normal jumpcoil animation when you have other weapons equipped
+
 beatrun.toolsmenu.gameplay.quickturnground=Quickturn Ground
 beatrun.toolsmenu.gameplay.quickturngrounddesc=Toggles quickturning with secondary attack while on the ground
 

--- a/gamemodes/beatrun/content/resource/localization/en/beatrun.properties
+++ b/gamemodes/beatrun/content/resource/localization/en/beatrun.properties
@@ -159,7 +159,7 @@ beatrun.toolsmenu.gameplay.animset1=Reanimated (by MTB)
 beatrun.toolsmenu.gameplay.animset2=Original (made by datae, fixed by MTB)
 
 beatrun.toolsmenu.gameplay.catalystcoil=Catalyst coil jump animation
-beatrun.toolsmenu.gameplay.catalystcoildesc=Can only be used when runnerhands is equipped, and will instead use normal jumpcoil animation when you have other weapons equipped
+beatrun.toolsmenu.gameplay.catalystcoildesc=Can only be used when runnerhands is equipped, and will instead use the normal coil jump animation when you have other weapons equipped
 
 beatrun.toolsmenu.gameplay.quickturnground=Quickturn Ground
 beatrun.toolsmenu.gameplay.quickturngrounddesc=Toggles quickturning with secondary attack while on the ground

--- a/gamemodes/beatrun/gamemode/cl/JumpAnim.lua
+++ b/gamemodes/beatrun/gamemode/cl/JumpAnim.lua
@@ -1,5 +1,6 @@
 local AnimSet = CreateClientConVar("Beatrun_AnimSet", "0", true, false, "")
 local AutoHandSwitching = CreateClientConVar("Beatrun_AutoHandSwitching", "1", true, false)
+local CatalystCoil = CreateClientConVar("Beatrun_CatalystCoil","0", true, false)
 
 -- Animations that use arms for auto hand switching
 local requiresArms = {
@@ -45,6 +46,7 @@ fbanims = {
 	jumpzipline = true,
 	springboardleftleg = true,
 	jumpcoilend = true,
+	jumpcoilcatalyst = true,
 	hangstraferight = true,
 	hangfoldedstart = true,
 	jumpslow = true,
@@ -144,6 +146,7 @@ local jumpanims = {
 	jumpidle = true,
 	jumpair = true,
 	jumpcoil = true,
+	jumpcoilcatalyst = true,
 	jumpzipline = true
 }
 
@@ -325,7 +328,8 @@ local armlock = {
 	wallrunright = true,
 	wallrunleft = true,
 	wallrunrightstart = true,
-	wallrunleftstart = true
+	wallrunleftstart = true,
+	jumpcoilcatalyst = true
 }
 
 local stillanims = {
@@ -494,7 +498,8 @@ local ignorezarm = {
 	hangfoldedheaveup = true,
 	wallrunverticalstart = true,
 	diestandlong = true,
-	vaultontohigh = true
+	vaultontohigh = true,
+	jumpcoilcatalyst = true
 }
 
 local nocyclereset = {
@@ -1357,6 +1362,13 @@ hook.Add("CalcViewModelView", "lol", function(wep, vm, oldpos, oldang, pos, ang)
 end)
 
 local function JumpAnim(event, ply)
+	
+	if CatalystCoil:GetBool() and event == "coil" and ply:UsingRH() then
+		eventslut.coil = "jumpcoilcatalyst"
+	else
+		eventslut.coil = "jumpcoil"
+	end
+	
 	if events[event] then
 		local wasjumpanim = fbanims[BodyAnimString] and IsValid(BodyAnim)
 

--- a/gamemodes/beatrun/gamemode/cl/ToolMenuSettings.lua
+++ b/gamemodes/beatrun/gamemode/cl/ToolMenuSettings.lua
@@ -264,6 +264,9 @@ hook.Add("PopulateToolMenu", "Beatrun_ToolMenu", function()
 		animsetting:AddChoice("#beatrun.toolsmenu.gameplay.animset1", 0)
 		animsetting:AddChoice("#beatrun.toolsmenu.gameplay.animset2", 1)
 		animsetting:SetSortItems(false)
+		
+		panel:CheckBox("#beatrun.toolsmenu.gameplay.catalystcoil", "Beatrun_CatalystCoil")
+		panel:ControlHelp("#beatrun.toolsmenu.gameplay.catalystcoildesc")
 
 		panel:CheckBox("#beatrun.toolsmenu.gameplay.quickturnground", "Beatrun_QuickturnGround")
 		panel:ControlHelp("#beatrun.toolsmenu.gameplay.quickturngrounddesc")


### PR DESCRIPTION
Based on MTB's idea
Added a way to switch to catalyst style jump coil.
Can only be used when runnerhands is equipped, and will instead use the normal coil jump animation when you have other weapons equipped