### PR TITLE
Fix body angle on ladders

### DIFF
--- a/gamemodes/beatrun/gamemode/cl/JumpAnim.lua
+++ b/gamemodes/beatrun/gamemode/cl/JumpAnim.lua
@@ -1948,7 +1948,7 @@ local function JumpThink()
 				_ang[3] = 0
 
 				if vel_l > 0 or BodyAnimString == "walktostandleft" or BodyAnimString == "crouchtostandleft" or ply:Crouching() or IsValid(ply:GetBalanceEntity()) then
-					if newang:Forward():Dot(ang:Forward()) > -0.25 then
+					if newang:Forward():Dot(ang:Forward()) > -0.25 and ply:GetMoveType() ~= MOVETYPE_LADDER then
 						ply.OrigEyeAng = newang
 
 						BodyAnim:SetAngles(newang)


### PR DESCRIPTION
When on a ladder sometimes your body angle is set to be sideways
this fix disables that and also makes your bodyanim only be in a direction your looking