### PR TITLE
Immediately change viewmodel with EPMS "Apply" button

### DIFF
--- a/gamemodes/beatrun/gamemode/player_class/player_beatrun.lua
+++ b/gamemodes/beatrun/gamemode/player_class/player_beatrun.lua
@@ -139,23 +139,26 @@ function PLAYER:Loadout()
 end
 
 function PLAYER:SetModel()
-	BaseClass.SetModel(self)
+    BaseClass.SetModel(self)
 
-	local skin = self.Player:GetInfoNum("cl_playerskin", 0)
+    local skin = self.Player:GetInfoNum("cl_playerskin", 0)
+    self.Player:SetSkin(skin)
 
-	self.Player:SetSkin(skin)
+    local groups = self.Player:GetInfo("cl_playerbodygroups")
 
-	local groups = self.Player:GetInfo("cl_playerbodygroups")
+    if groups == nil then
+        groups = ""
+    end
 
-	if groups == nil then
-		groups = ""
-	end
+    local groups = string.Explode(" ", groups)
 
-	local groups = string.Explode(" ", groups)
+    local numBodyGroups = 0
+    local ok, result = pcall(self.Player.GetNumBodyGroups, self.Player)
+    if ok then numBodyGroups = result or 0 end
 
-	for k = 0, self.Player:GetNumBodyGroups() - 1 do
-		self.Player:SetBodygroup(k, tonumber(groups[k + 1]) or 0)
-	end
+    for k = 0, numBodyGroups - 1 do
+        self.Player:SetBodygroup(k, tonumber(groups[k + 1]) or 0)
+    end
 end
 
 if SERVER then
@@ -455,6 +458,170 @@ hook.Add("PlayerSpawn", "ResetStateTransition", function(ply, transition)
 			ply.ClimbingTrace = nil
 		end
 	end)
+end)
+
+if SERVER then
+    local LastModels = {}
+
+    hook.Add("Think", "BeatrunCheckPlayerModelChange", function()
+        for _, ply in ipairs(player.GetAll()) do
+            if not IsValid(ply) then continue end
+
+            local mdl = ply:GetModel() or ""
+            local clModel = ply:GetInfo("cl_playermodel") or ""
+            if LastModels[ply] == nil then
+                LastModels[ply] = mdl
+                continue
+            end
+
+            if mdl ~= LastModels[ply] then
+                LastModels[ply] = mdl
+
+                timer.Simple(0, function()
+                    if not IsValid(ply) then return end
+
+                    player_manager.RunClass(ply, "SetModel")
+                    ply:SetupHands()
+                end)
+            end
+        end
+    end)
+end
+
+local lastCheckedModel = ""
+local lastCheckedHands = ""
+
+local function SafeGetBodyGroups(ent)
+    if not IsValid(ent) then return nil end
+    local ok, result = pcall(ent.GetBodyGroups, ent)
+    if ok and istable(result) then return result end
+    return nil
+end
+
+local function SafeGetNumBodyGroups(ent)
+    if not IsValid(ent) then return 0 end
+    local ok, result = pcall(ent.GetNumBodyGroups, ent)
+    if ok and isnumber(result) then return result end
+    return 0
+end
+
+hook.Add("Think", "Beatrun_InstantModelUpdate", function()
+    if not IsValid(BodyAnim) then return end
+    if not IsValid(BodyAnimMDL) then return end
+
+    local ply = LocalPlayer()
+    if not IsValid(ply) then return end
+
+    local mdl = ply:GetModel() or ""
+    local handsEnt = ply:GetHands()
+    local hands = IsValid(handsEnt) and handsEnt:GetModel() or ""
+
+    if mdl == "" then return end
+
+    if mdl ~= lastCheckedModel or hands ~= lastCheckedHands then
+        lastCheckedModel = mdl
+        lastCheckedHands = hands
+
+        local currentMdl = BodyAnimMDL:GetModel() or ""
+        if currentMdl ~= mdl then
+            local ok = pcall(function()
+                BodyAnimMDL:SetModel(mdl)
+                BodyAnimMDL:SnatchModelInstance(ply)
+            end)
+            if not ok then
+                lastCheckedModel = ""
+                return
+            end
+        end
+        local bodygroups = SafeGetBodyGroups(ply)
+        if bodygroups then
+            for num, _ in pairs(bodygroups) do
+                local bgValue = 0
+                pcall(function()
+                    bgValue = ply:GetBodygroup(num - 1)
+                end)
+                pcall(function()
+                    BodyAnimMDL:SetBodygroup(num - 1, bgValue)
+                end)
+            end
+        end
+
+        pcall(function()
+            BodyAnimMDL:SetSkin(ply:GetSkin())
+        end)
+
+        if IsValid(BodyAnimMDLarm) and hands ~= "" then
+            local currentHandsMdl = BodyAnimMDLarm:GetModel() or ""
+            if currentHandsMdl ~= hands then
+                local ok = pcall(function()
+                    BodyAnimMDLarm:SetModel(hands)
+                end)
+                if not ok then
+                    lastCheckedHands = ""
+                    return
+                end
+            end
+
+            local handBodygroups = SafeGetBodyGroups(handsEnt)
+            if handBodygroups then
+                for num, _ in pairs(handBodygroups) do
+                    local bgValue = 0
+                    pcall(function()
+                        bgValue = handsEnt:GetBodygroup(num - 1)
+                    end)
+                    pcall(function()
+                        BodyAnimMDLarm:SetBodygroup(num - 1, bgValue)
+                    end)
+                end
+            end
+
+            pcall(function()
+                BodyAnimMDLarm:SetSkin(handsEnt:GetSkin())
+            end)
+        end
+
+        if playermodelbones then
+			for _, v in ipairs(playermodelbones) do
+				local b = BodyAnimMDL:LookupBone(v)
+
+				if b then
+					pcall(function()
+						BodyAnimMDL:ManipulateBoneScale(b, vector_origin)
+					end)
+				end
+			end
+		end
+
+        local bs = GetConVar("Beatrun_BodyScale"):GetFloat()
+        local av = Vector(bs, bs, bs)
+        for i = 0, BodyAnimMDL:GetBoneCount() - 1 do
+            local bonename = BodyAnimMDL:GetBoneName(i)
+            if bonename and not armbones[bonename] then
+                pcall(function()
+                    BodyAnimMDL:ManipulateBoneScale(i, av)
+                end)
+            end
+        end
+
+        local as = GetConVar("Beatrun_ArmBodyScale"):GetFloat()
+        local aav = Vector(as, as, as)
+        if IsValid(BodyAnimMDLarm) then
+            for i = 0, BodyAnimMDLarm:GetBoneCount() - 1 do
+                pcall(function()
+                    BodyAnimMDLarm:ManipulateBoneScale(i, aav)
+                end)
+            end
+        end
+
+        pcall(function()
+            BodyAnimMDL:InvalidateBoneCache()
+        end)
+        if IsValid(BodyAnimMDLarm) then
+            pcall(function()
+                BodyAnimMDLarm:InvalidateBoneCache()
+            end)
+        end
+    end
 end)
 
 player_manager.RegisterClass("player_beatrun", PLAYER, "player_default")

--- a/gamemodes/beatrun/gamemode/player_class/player_beatrun.lua
+++ b/gamemodes/beatrun/gamemode/player_class/player_beatrun.lua
@@ -512,7 +512,7 @@ local function GetBodygroupsString(ent)
 	if not IsValid(ent) then return "" end
 	local num = SafeGetNumBodyGroups(ent)
 	if num <= 0 then return "" end
-	
+
 	local parts = {}
 	for i = 0, num - 1 do
 		local ok, bg = pcall(ent.GetBodygroup, ent, i)

--- a/gamemodes/beatrun/gamemode/player_class/player_beatrun.lua
+++ b/gamemodes/beatrun/gamemode/player_class/player_beatrun.lua
@@ -1,10 +1,7 @@
-AddCSLuaFile()
-
+﻿AddCSLuaFile()
 DEFINE_BASECLASS("player_default")
-
 if CLIENT then
 	local lframeswepclass = lframeswepclass or ""
-
 	CreateConVar("cl_playercolor", "0.24 0.34 0.41", { FCVAR_ARCHIVE, FCVAR_USERINFO, FCVAR_DONTRECORD }, "The value is a Vector - so between 0-1 - not between 0-255")
 	CreateConVar("cl_weaponcolor", "0.30 1.80 2.10", { FCVAR_ARCHIVE, FCVAR_USERINFO, FCVAR_DONTRECORD }, "The value is a Vector - so between 0-1 - not between 0-255")
 	CreateConVar("cl_playerskin", "0", { FCVAR_ARCHIVE, FCVAR_USERINFO, FCVAR_DONTRECORD }, "The skin to use, if the model has any")
@@ -12,21 +9,16 @@ if CLIENT then
 end
 
 local PLAYER = {}
-
 PLAYER.DuckSpeed = 0.01 -- How fast to go from not ducking, to ducking
 PLAYER.UnDuckSpeed = 0.01 -- How fast to go from ducking, to not ducking
-
 PLAYER.TauntCam = TauntCamera()
-
 PLAYER.WalkSpeed = 200
 PLAYER.RunSpeed = 400
-
 function PLAYER:SetupDataTables()
 	BaseClass.SetupDataTables(self)
 	self.Player:NetworkVar("Float", 0, "MEMoveLimit")
 	self.Player:NetworkVar("Float", 1, "MESprintDelay")
 	self.Player:NetworkVar("Float", 2, "MEAng")
-
 	self.Player:NetworkVar("Int", 0, "Climbing")
 	self.Player:NetworkVar("Float", 3, "ClimbingTime")
 	self.Player:NetworkVar("Vector", 0, "ClimbingStart")
@@ -34,14 +26,12 @@ function PLAYER:SetupDataTables()
 	self.Player:NetworkVar("Vector", 7, "ClimbingEndOld")
 	self.Player:NetworkVar("Float", 24, "ClimbingDelay")
 	self.Player:NetworkVar("Angle", 3, "ClimbingAngle")
-
 	self.Player:NetworkVar("Int", 1, "Wallrun")
 	self.Player:NetworkVar("Float", 4, "WallrunTime")
 	self.Player:NetworkVar("Float", 5, "WallrunSoundTime")
 	self.Player:NetworkVar("Vector", 2, "WallrunDir")
 	self.Player:NetworkVar("Vector", 8, "WallrunOrigVel")
 	self.Player:NetworkVar("Int", 4, "WallrunCount")
-
 	self.Player:NetworkVar("Bool", 0, "Sliding")
 	self.Player:NetworkVar("Float", 6, "SlidingTime")
 	self.Player:NetworkVar("Float", 7, "SlidingDelay")
@@ -51,30 +41,22 @@ function PLAYER:SetupDataTables()
 	self.Player:NetworkVar("Bool", 9, "SlidingSlippery")
 	self.Player:NetworkVar("Float", 20, "SlidingSlipperyUpdate")
 	self.Player:NetworkVar("Angle", 2, "SlidingAngle")
-
 	self.Player:NetworkVar("Bool", 1, "StepRight")
 	self.Player:NetworkVar("Float", 8, "StepRelease")
-
 	self.Player:NetworkVar("Bool", 2, "Grappling")
 	self.Player:NetworkVar("Vector", 3, "GrapplePos")
 	self.Player:NetworkVar("Float", 29, "GrappleLength")
-
 	self.Player:NetworkVar("Entity", 0, "Swingbar")
-
 	self.Player:NetworkVar("Bool", 3, "CrouchJump")
 	self.Player:NetworkVar("Float", 9, "CrouchJumpTime")
 	self.Player:NetworkVar("Bool", 12, "CrouchJumpBlocked")
-
 	self.Player:NetworkVar("Float", 9, "SafetyRollKeyTime")
 	self.Player:NetworkVar("Float", 10, "SafetyRollTime")
 	self.Player:NetworkVar("Angle", 0, "SafetyRollAng")
-
 	self.Player:NetworkVar("Bool", 4, "Quickturn")
 	self.Player:NetworkVar("Float", 10, "QuickturnTime")
 	self.Player:NetworkVar("Angle", 1, "QuickturnAng")
-
 	self.Player:NetworkVar("Bool", 5, "WallrunElevated")
-
 	--We have to store this info on the player as multiple people can use one swingbar
 	self.Player:NetworkVar("Float", 11, "SBOffset")
 	self.Player:NetworkVar("Float", 12, "SBOffsetSpeed")
@@ -83,19 +65,14 @@ function PLAYER:SetupDataTables()
 	self.Player:NetworkVar("Int", 2, "SBPeak")
 	self.Player:NetworkVar("Bool", 6, "SBDir")
 	self.Player:NetworkVar("Entity", 1, "SwingbarLast")
-
 	self.Player:NetworkVar("Entity", 2, "Swingpipe")
 	self.Player:NetworkVar("Entity", 3, "Rabbit")
 	self.Player:NetworkVar("Int", 3, "RabbitSeat")
-
 	self.Player:NetworkVar("Float", 15, "OverdriveCharge")
 	self.Player:NetworkVar("Float", 16, "OverdriveMult")
-
 	self.Player:NetworkVar("Bool", 7, "JumpTurn")
 	self.Player:NetworkVar("Float", 17, "JumpTurnRecovery")
-
 	self.Player:NetworkVar("Bool", 8, "WasOnGround")
-
 	self.Player:NetworkVar("Entity", 4, "Ladder")
 	self.Player:NetworkVar("Float", 21, "LadderDelay")
 	self.Player:NetworkVar("Float", 22, "LadderHeight")
@@ -104,21 +81,17 @@ function PLAYER:SetupDataTables()
 	self.Player:NetworkVar("Vector", 5, "LadderStartPos")
 	self.Player:NetworkVar("Vector", 6, "LadderEndPos")
 	self.Player:NetworkVar("Float", 23, "LadderLerp")
-
 	self.Player:NetworkVar("Entity", 5, "Zipline")
 	self.Player:NetworkVar("Float", 21, "ZiplineStart")
 	self.Player:NetworkVar("Float", 22, "ZiplineFraction")
 	self.Player:NetworkVar("Float", 23, "ZiplineSpeed")
 	self.Player:NetworkVar("Float", 25, "ZiplineDelay")
-
 	self.Player:NetworkVar("Int", 5, "MeleeDamage")
 	self.Player:NetworkVar("Float", 26, "MeleeTime")
 	self.Player:NetworkVar("Float", 27, "MeleeDelay")
 	self.Player:NetworkVar("Int", 6, "Melee")
-
 	self.Player:NetworkVar("Float", 28, "Balance")
 	self.Player:NetworkVar("Entity", 6, "BalanceEntity")
-
 	self.Player:NetworkVar("Bool", 13, "Dive")
 end
 
@@ -131,7 +104,6 @@ function PLAYER:Loadout()
 
 	self.Player:Give("runnerhands")
 	self.Player:SelectWeapon("runnerhands")
-
 	self.Player:SetJumpPower(230)
 	self.Player:SetCrouchedWalkSpeed(0.5)
 	-- self.Player:SetFOV(self.Player:GetInfoNum("Beatrun_FOV", 100))
@@ -140,75 +112,50 @@ end
 
 function PLAYER:SetModel()
 	BaseClass.SetModel(self)
-
 	local skin = self.Player:GetInfoNum("cl_playerskin", 0)
 	self.Player:SetSkin(skin)
-
 	local groups = self.Player:GetInfo("cl_playerbodygroups")
-
-	if groups == nil then
-		groups = ""
-	end
-
+	if groups == nil then groups = "" end
 	local groups = string.Explode(" ", groups)
-
 	local numBodyGroups = 0
 	local ok, result = pcall(self.Player.GetNumBodyGroups, self.Player)
 	if ok then numBodyGroups = result or 0 end
-
 	for k = 0, numBodyGroups - 1 do
 		self.Player:SetBodygroup(k, tonumber(groups[k + 1]) or 0)
 	end
 end
 
-if SERVER then
-	util.AddNetworkString("BeatrunSpawn")
-end
-
+if SERVER then util.AddNetworkString("BeatrunSpawn") end
 function PLAYER:Spawn()
 	BaseClass.Spawn(self)
-
 	local ply = self.Player
 	local col = ply:GetInfo("cl_playercolor")
-
 	ply:SetPlayerColor(Vector(col))
-
-	local faststartmult = (ply:GetInfoNum("Beatrun_FastStart", 0) > 0 and 0.5) or 1
+	local faststartmult = ply:GetInfoNum("Beatrun_FastStart", 0) > 0 and 0.5 or 1
 	local col = Vector(ply:GetInfo("cl_weaponcolor"))
-
-	if col:Length() < 0.001 then
-		col = Vector(0.001, 0.001, 0.001)
-	end
-
+	if col:Length() < 0.001 then col = Vector(0.001, 0.001, 0.001) end
 	ply:SetWeaponColor(col)
-
 	local CPSave = false
-
 	if Course_Name ~= "" and Course_StartPos ~= vector_origin then
 		if ply:GetInfoNum("Beatrun_CPSave", 0) >= 1 and ply:GetNW2Float("CPNum", 1) > 1 and ply.CPSavePos and ply.LastSpawnTime + 0.6 < CurTime() then
 			ply:SetPos(ply.CPSavePos)
 			ply:SetEyeAngles(ply.CPSaveAng)
 			ply:SetLocalVelocity(ply.CPSaveVel)
 			ply:LoadParkourState()
-
 			-- ply:SetNW2Float("RetryCount", ply:GetNW2Float("RetryCount", 0) + 1)
-
 			CPSave = true
 		else
 			ply.CPSavePos = nil
 			ply.CPsaveAng = nil
 			ply.CPsaveVel = nil
-
 			ply:SetPos(Course_StartPos)
 			ply:SetEyeAngles(Angle(0, Course_StartAng, 0))
 			ply:SetLocalVelocity(vector_origin)
-
 			--Failsafe
 			timer.Simple(0.1, function()
 				ply:SetLocalVelocity(vector_origin)
 				ply:SetPos(Course_StartPos)
 			end)
-
 			-- ReplayStop(ply)
 			-- ReplayStart(ply)
 		end
@@ -220,34 +167,21 @@ function PLAYER:Spawn()
 	end
 
 	if not CPSave then
-		ply.Course_StartTime = CurTime() + (2 * faststartmult)
-
+		ply.Course_StartTime = CurTime() + 2 * faststartmult
 		net.Start("BeatrunSpawn")
-			net.WriteFloat(CurTime())
-			net.WriteBool(ply.InReplay)
+		net.WriteFloat(CurTime())
+		net.WriteBool(ply.InReplay)
 		net.Send(ply)
-
-		ply.SpawnFreezeTime = CurTime() + (1.75 * faststartmult)
+		ply.SpawnFreezeTime = CurTime() + 1.75 * faststartmult
 	end
 
 	ply:SetCustomCollisionCheck(true)
 	ply:SetCollisionGroup(COLLISION_GROUP_PASSABLE_DOOR)
-
-	if GetGlobalBool("GM_DATATHEFT") then
-		ply:DataTheft_Bank()
-	end
-
+	if GetGlobalBool("GM_DATATHEFT") then ply:DataTheft_Bank() end
 	ply:SetAvoidPlayers(false)
 	ply:SetLaggedMovementValue(0) -- otherwise they drift off
-
-	timer.Simple(0.1, function()
-		ply:SetLaggedMovementValue(1)
-	end)
-
-	if ply.SlideLoopSound and ply.SlideLoopSound.Stop then
-		ply.SlideLoopSound:Stop()
-	end
-
+	timer.Simple(0.1, function() ply:SetLaggedMovementValue(1) end)
+	if ply.SlideLoopSound and ply.SlideLoopSound.Stop then ply.SlideLoopSound:Stop() end
 	ply:ResetParkourState()
 	ply:SetOverdriveCharge(0)
 	ply:SetOverdriveMult(1)
@@ -256,41 +190,26 @@ end
 
 hook.Add("IsSpawnpointSuitable", "CheckSpawnPoint", function(ply, spawnpointent, bMakeSuitable)
 	if not GetGlobalBool("GM_DATATHEFT") or not GetGlobalBool("GM_DEATHMATCH") then return end
-
 	local pos = spawnpointent:GetPos()
-
 	-- Note that we're searching the default hull size here for a player in the way of our spawning.
 	-- This seems pretty rough, seeing as our player's hull could be different.. but it should do the job.
 	-- (HL2DM kills everything within a 128 unit radius)
 	local ents = ents.FindInBox(pos + Vector(-16, -16, 0), pos + Vector(16, 16, 72))
 	local Blockers = 0
-
 	for _, v in ipairs(ents) do
 		if v:IsPlayer() and v:Alive() then
 			Blockers = Blockers + 1
-
-			if bMakeSuitable then
-				v:Kill()
-			end
+			if bMakeSuitable then v:Kill() end
 		end
 	end
 
 	if bMakeSuitable then return true end
 	if Blockers > 0 then return false end
-
 	return true
 end)
 
-hook.Add("SetupMove", "SpawnFreeze", function(ply, mv, cmd)
-	if ply.SpawnFreezeTime and Course_Name ~= "" and Course_StartPos ~= vector_origin and Course_StartPos and ply.SpawnFreezeTime > CurTime() then
-		mv:SetOrigin(Course_StartPos)
-	end
-end)
-
-hook.Add("ShouldCollide", "Beatrun_NoPlayerCollisions", function(ent1, ent2)
-	if ent1:IsPlayer() and ent2.NoPlayerCollisions then return false end
-end)
-
+hook.Add("SetupMove", "SpawnFreeze", function(ply, mv, cmd) if ply.SpawnFreezeTime and Course_Name ~= "" and Course_StartPos ~= vector_origin and Course_StartPos and ply.SpawnFreezeTime > CurTime() then mv:SetOrigin(Course_StartPos) end end)
+hook.Add("ShouldCollide", "Beatrun_NoPlayerCollisions", function(ent1, ent2) if ent1:IsPlayer() and ent2.NoPlayerCollisions then return false end end)
 function PLAYER:ShouldDrawLocal()
 	if self.TauntCam:ShouldDrawLocalPlayer(self.Player, self.Player:IsPlayingTaunt()) then return true end
 end
@@ -302,15 +221,12 @@ end
 function PLAYER:CalcView(view)
 	-- local mult = (self.Player:InOverdrive() and 1.1) or 1
 	-- local fov = GetConVar("Beatrun_FOV"):GetInt()
-
 	-- view.fov = fov * mult
-
 	if self.TauntCam:CalcView(view, self.Player, self.Player:IsPlayingTaunt()) then return true end
 end
 
 function PLAYER:GetHandsModel()
 	local cl_playermodel = self.Player:GetInfo("cl_playermodel")
-
 	return player_manager.TranslatePlayerHands(cl_playermodel)
 end
 
@@ -322,14 +238,10 @@ end
 
 hook.Add("FinishMove", "BeatrunRHVelocity", function(ply, mv)
 	local activewep = ply:GetActiveWeapon()
-
-	if ply:UsingRH() and activewep.SetOwnerVelocity then
-		activewep:SetOwnerVelocity(math.Round(mv:GetVelocity():Length()))
-	end
+	if ply:UsingRH() and activewep.SetOwnerVelocity then activewep:SetOwnerVelocity(math.Round(mv:GetVelocity():Length())) end
 end)
 
 local meta = FindMetaTable("Player")
-
 function meta:ResetParkourState()
 	self:SetSliding(false)
 	self:SetCrouchJump(false)
@@ -358,48 +270,19 @@ function meta:ResetParkourState()
 	self:SetJumpTurn(false)
 	self:SetDive(false)
 	self:SetViewOffsetDucked(Vector(0, 0, 32))
-
 	self.Swingrope = nil
 	self.DiveSliding = false
-
 	ParkourEvent("jump", self)
-
 	self:StopSound("ZiplineLoop")
 end
 
 function meta:SaveParkourState()
-	self.ParkourSave = {
-		self:GetSliding(),
-		self:GetCrouchJump(),
-		self:GetQuickturn(),
-		self:GetGrappling(),
-		self:GetSwingbar(),
-		self:GetZipline(),
-		self:GetLadder(),
-		self:GetMantle(),
-		self:GetWallrun(),
-		self:GetMEMoveLimit(),
-		self:GetMESprintDelay(),
-		self:GetMEAng(),
-		self:GetClimbing(),
-		self:GetClimbingTime(),
-		self:GetWallrunTime(),
-		self:GetWallrunSoundTime(),
-		self:GetSlidingTime(),
-		self:GetSlidingDelay(),
-		self:GetCrouchJumpTime(),
-		self:GetSafetyRollKeyTime(),
-		self:GetSafetyRollTime(),
-		self:GetQuickturnTime(),
-		self:GetJumpTurn(),
-		self:GetDive(),
-	}
+	self.ParkourSave = { self:GetSliding(), self:GetCrouchJump(), self:GetQuickturn(), self:GetGrappling(), self:GetSwingbar(), self:GetZipline(), self:GetLadder(), self:GetMantle(), self:GetWallrun(), self:GetMEMoveLimit(), self:GetMESprintDelay(), self:GetMEAng(), self:GetClimbing(), self:GetClimbingTime(), self:GetWallrunTime(), self:GetWallrunSoundTime(), self:GetSlidingTime(), self:GetSlidingDelay(), self:GetCrouchJumpTime(), self:GetSafetyRollKeyTime(), self:GetSafetyRollTime(), self:GetQuickturnTime(), self:GetJumpTurn(), self:GetDive(), }
 end
 
 function meta:LoadParkourState()
 	local save = self.ParkourSave
 	if not save then return end
-
 	self:SetSliding(save[1])
 	self:SetCrouchJump(save[2])
 	self:SetQuickturn(save[3])
@@ -440,7 +323,6 @@ end
 
 function meta:InOverdrive()
 	if not self.GetOverdriveMult then return false end
-
 	return self:GetOverdriveMult() ~= 1
 end
 
@@ -462,11 +344,9 @@ end)
 
 if SERVER then
 	local LastModels = {}
-
 	hook.Add("Think", "BeatrunCheckPlayerModelChange", function()
 		for _, ply in ipairs(player.GetAll()) do
 			if not IsValid(ply) then continue end
-
 			local mdl = ply:GetModel() or ""
 			if LastModels[ply] == nil then
 				LastModels[ply] = mdl
@@ -475,10 +355,8 @@ if SERVER then
 
 			if mdl ~= LastModels[ply] then
 				LastModels[ply] = mdl
-
 				timer.Simple(0, function()
 					if not IsValid(ply) then return end
-
 					player_manager.RunClass(ply, "SetModel")
 					ply:SetupHands()
 				end)
@@ -493,7 +371,6 @@ local lastCheckedSkin = 0
 local lastCheckedBodygroups = ""
 local lastCheckedHandsSkin = 0
 local lastCheckedHandsBodygroups = ""
-
 local function SafeGetNumBodyGroups(ent)
 	if not IsValid(ent) then return 0 end
 	local ok, result = pcall(ent.GetNumBodyGroups, ent)
@@ -512,7 +389,6 @@ local function GetBodygroupsString(ent)
 	if not IsValid(ent) then return "" end
 	local num = SafeGetNumBodyGroups(ent)
 	if num <= 0 then return "" end
-
 	local parts = {}
 	for i = 0, num - 1 do
 		local ok, bg = pcall(ent.GetBodygroup, ent, i)
@@ -524,10 +400,8 @@ end
 hook.Add("Think", "Beatrun_InstantModelUpdate", function()
 	if not IsValid(BodyAnim) then return end
 	if not IsValid(BodyAnimMDL) then return end
-
 	local ply = LocalPlayer()
 	if not IsValid(ply) then return end
-
 	local mdl = ply:GetModel() or ""
 	local handsEnt = ply:GetHands()
 	local hands = IsValid(handsEnt) and handsEnt:GetModel() or ""
@@ -535,27 +409,20 @@ hook.Add("Think", "Beatrun_InstantModelUpdate", function()
 	local bodygroups = GetBodygroupsString(ply)
 	local handsSkin = IsValid(handsEnt) and handsEnt:GetSkin() or 0
 	local handsBodygroups = GetBodygroupsString(handsEnt)
-
 	if mdl == "" then return end
-
 	local modelChanged = mdl ~= lastCheckedModel
 	local handsChanged = hands ~= lastCheckedHands
 	local skinChanged = skin ~= lastCheckedSkin
 	local bgChanged = bodygroups ~= lastCheckedBodygroups
 	local handsSkinChanged = handsSkin ~= lastCheckedHandsSkin
 	local handsBgChanged = handsBodygroups ~= lastCheckedHandsBodygroups
-
-	if not modelChanged and not handsChanged and not skinChanged and not bgChanged and not handsSkinChanged and not handsBgChanged then
-		return
-	end
-
+	if not modelChanged and not handsChanged and not skinChanged and not bgChanged and not handsSkinChanged and not handsBgChanged then return end
 	lastCheckedModel = mdl
 	lastCheckedHands = hands
 	lastCheckedSkin = skin
 	lastCheckedBodygroups = bodygroups
 	lastCheckedHandsSkin = handsSkin
 	lastCheckedHandsBodygroups = handsBodygroups
-
 	if modelChanged then
 		local currentMdl = BodyAnimMDL:GetModel() or ""
 		if currentMdl ~= mdl then
@@ -563,6 +430,7 @@ hook.Add("Think", "Beatrun_InstantModelUpdate", function()
 				BodyAnimMDL:SetModel(mdl)
 				BodyAnimMDL:SnatchModelInstance(ply)
 			end)
+
 			if not ok then
 				lastCheckedModel = ""
 				return
@@ -570,23 +438,14 @@ hook.Add("Think", "Beatrun_InstantModelUpdate", function()
 		end
 	end
 
-	if skinChanged or modelChanged then
-		pcall(function()
-			BodyAnimMDL:SetSkin(skin)
-		end)
-	end
-
+	if skinChanged or modelChanged then pcall(function() BodyAnimMDL:SetSkin(skin) end) end
 	if bgChanged or modelChanged then
 		local bodygroupsTable = SafeGetBodyGroups(ply)
 		if bodygroupsTable then
 			for num, _ in pairs(bodygroupsTable) do
 				local bgValue = 0
-				pcall(function()
-					bgValue = ply:GetBodygroup(num - 1)
-				end)
-				pcall(function()
-					BodyAnimMDL:SetBodygroup(num - 1, bgValue)
-				end)
+				pcall(function() bgValue = ply:GetBodygroup(num - 1) end)
+				pcall(function() BodyAnimMDL:SetBodygroup(num - 1, bgValue) end)
 			end
 		end
 	end
@@ -595,9 +454,7 @@ hook.Add("Think", "Beatrun_InstantModelUpdate", function()
 		if handsChanged then
 			local currentHandsMdl = BodyAnimMDLarm:GetModel() or ""
 			if currentHandsMdl ~= hands then
-				local ok = pcall(function()
-					BodyAnimMDLarm:SetModel(hands)
-				end)
+				local ok = pcall(function() BodyAnimMDLarm:SetModel(hands) end)
 				if not ok then
 					lastCheckedHands = ""
 					return
@@ -605,23 +462,14 @@ hook.Add("Think", "Beatrun_InstantModelUpdate", function()
 			end
 		end
 
-		if handsSkinChanged or handsChanged then
-			pcall(function()
-				BodyAnimMDLarm:SetSkin(handsSkin)
-			end)
-		end
-
+		if handsSkinChanged or handsChanged then pcall(function() BodyAnimMDLarm:SetSkin(handsSkin) end) end
 		if handsBgChanged or handsChanged then
 			local handBodygroups = SafeGetBodyGroups(handsEnt)
 			if handBodygroups then
 				for num, _ in pairs(handBodygroups) do
 					local bgValue = 0
-					pcall(function()
-						bgValue = handsEnt:GetBodygroup(num - 1)
-					end)
-					pcall(function()
-						BodyAnimMDLarm:SetBodygroup(num - 1, bgValue)
-					end)
+					pcall(function() bgValue = handsEnt:GetBodygroup(num - 1) end)
+					pcall(function() BodyAnimMDLarm:SetBodygroup(num - 1, bgValue) end)
 				end
 			end
 		end
@@ -630,11 +478,7 @@ hook.Add("Think", "Beatrun_InstantModelUpdate", function()
 	if modelChanged and playermodelbones then
 		for _, v in ipairs(playermodelbones) do
 			local b = BodyAnimMDL:LookupBone(v)
-			if b then
-				pcall(function()
-					BodyAnimMDL:ManipulateBoneScale(b, vector_origin)
-				end)
-			end
+			if b then pcall(function() BodyAnimMDL:ManipulateBoneScale(b, vector_origin) end) end
 		end
 	end
 
@@ -642,31 +486,19 @@ hook.Add("Think", "Beatrun_InstantModelUpdate", function()
 	local av = Vector(bs, bs, bs)
 	for i = 0, BodyAnimMDL:GetBoneCount() - 1 do
 		local bonename = BodyAnimMDL:GetBoneName(i)
-		if bonename and not armbones[bonename] then
-			pcall(function()
-				BodyAnimMDL:ManipulateBoneScale(i, av)
-			end)
-		end
+		if bonename and not armbones[bonename] then pcall(function() BodyAnimMDL:ManipulateBoneScale(i, av) end) end
 	end
 
 	local as = GetConVar("Beatrun_ArmBodyScale"):GetFloat()
 	local aav = Vector(as, as, as)
 	if IsValid(BodyAnimMDLarm) then
 		for i = 0, BodyAnimMDLarm:GetBoneCount() - 1 do
-			pcall(function()
-				BodyAnimMDLarm:ManipulateBoneScale(i, aav)
-			end)
+			pcall(function() BodyAnimMDLarm:ManipulateBoneScale(i, aav) end)
 		end
 	end
 
-	pcall(function()
-		BodyAnimMDL:InvalidateBoneCache()
-	end)
-	if IsValid(BodyAnimMDLarm) then
-		pcall(function()
-			BodyAnimMDLarm:InvalidateBoneCache()
-		end)
-	end
+	pcall(function() BodyAnimMDL:InvalidateBoneCache() end)
+	if IsValid(BodyAnimMDLarm) then pcall(function() BodyAnimMDLarm:InvalidateBoneCache() end) end
 end)
 
 player_manager.RegisterClass("player_beatrun", PLAYER, "player_default")

--- a/gamemodes/beatrun/gamemode/player_class/player_beatrun.lua
+++ b/gamemodes/beatrun/gamemode/player_class/player_beatrun.lua
@@ -490,6 +490,17 @@ end
 
 local lastCheckedModel = ""
 local lastCheckedHands = ""
+local lastCheckedSkin = 0
+local lastCheckedBodygroups = ""
+local lastCheckedHandsSkin = 0
+local lastCheckedHandsBodygroups = ""
+
+local function SafeGetNumBodyGroups(ent)
+    if not IsValid(ent) then return 0 end
+    local ok, result = pcall(ent.GetNumBodyGroups, ent)
+    if ok and isnumber(result) then return result end
+    return 0
+end
 
 local function SafeGetBodyGroups(ent)
     if not IsValid(ent) then return nil end
@@ -498,11 +509,17 @@ local function SafeGetBodyGroups(ent)
     return nil
 end
 
-local function SafeGetNumBodyGroups(ent)
-    if not IsValid(ent) then return 0 end
-    local ok, result = pcall(ent.GetNumBodyGroups, ent)
-    if ok and isnumber(result) then return result end
-    return 0
+local function GetBodygroupsString(ent)
+    if not IsValid(ent) then return "" end
+    local num = SafeGetNumBodyGroups(ent)
+    if num <= 0 then return "" end
+    
+    local parts = {}
+    for i = 0, num - 1 do
+        local ok, bg = pcall(ent.GetBodygroup, ent, i)
+        table.insert(parts, tostring(ok and bg or 0))
+    end
+    return table.concat(parts, ",")
 end
 
 hook.Add("Think", "Beatrun_InstantModelUpdate", function()
@@ -515,13 +532,32 @@ hook.Add("Think", "Beatrun_InstantModelUpdate", function()
     local mdl = ply:GetModel() or ""
     local handsEnt = ply:GetHands()
     local hands = IsValid(handsEnt) and handsEnt:GetModel() or ""
+    local skin = ply:GetSkin() or 0
+    local bodygroups = GetBodygroupsString(ply)
+    local handsSkin = IsValid(handsEnt) and handsEnt:GetSkin() or 0
+    local handsBodygroups = GetBodygroupsString(handsEnt)
 
     if mdl == "" then return end
 
-    if mdl ~= lastCheckedModel or hands ~= lastCheckedHands then
-        lastCheckedModel = mdl
-        lastCheckedHands = hands
+    local modelChanged = mdl ~= lastCheckedModel
+    local handsChanged = hands ~= lastCheckedHands
+    local skinChanged = skin ~= lastCheckedSkin
+    local bgChanged = bodygroups ~= lastCheckedBodygroups
+    local handsSkinChanged = handsSkin ~= lastCheckedHandsSkin
+    local handsBgChanged = handsBodygroups ~= lastCheckedHandsBodygroups
 
+    if not modelChanged and not handsChanged and not skinChanged and not bgChanged and not handsSkinChanged and not handsBgChanged then
+        return
+    end
+
+    lastCheckedModel = mdl
+    lastCheckedHands = hands
+    lastCheckedSkin = skin
+    lastCheckedBodygroups = bodygroups
+    lastCheckedHandsSkin = handsSkin
+    lastCheckedHandsBodygroups = handsBodygroups
+
+    if modelChanged then
         local currentMdl = BodyAnimMDL:GetModel() or ""
         if currentMdl ~= mdl then
             local ok = pcall(function()
@@ -533,9 +569,18 @@ hook.Add("Think", "Beatrun_InstantModelUpdate", function()
                 return
             end
         end
-        local bodygroups = SafeGetBodyGroups(ply)
-        if bodygroups then
-            for num, _ in pairs(bodygroups) do
+    end
+
+    if skinChanged or modelChanged then
+        pcall(function()
+            BodyAnimMDL:SetSkin(skin)
+        end)
+    end
+
+    if bgChanged or modelChanged then
+        local bodygroupsTable = SafeGetBodyGroups(ply)
+        if bodygroupsTable then
+            for num, _ in pairs(bodygroupsTable) do
                 local bgValue = 0
                 pcall(function()
                     bgValue = ply:GetBodygroup(num - 1)
@@ -545,12 +590,10 @@ hook.Add("Think", "Beatrun_InstantModelUpdate", function()
                 end)
             end
         end
+    end
 
-        pcall(function()
-            BodyAnimMDL:SetSkin(ply:GetSkin())
-        end)
-
-        if IsValid(BodyAnimMDLarm) and hands ~= "" then
+    if IsValid(BodyAnimMDLarm) and hands ~= "" then
+        if handsChanged then
             local currentHandsMdl = BodyAnimMDLarm:GetModel() or ""
             if currentHandsMdl ~= hands then
                 local ok = pcall(function()
@@ -561,7 +604,15 @@ hook.Add("Think", "Beatrun_InstantModelUpdate", function()
                     return
                 end
             end
+        end
 
+        if handsSkinChanged or handsChanged then
+            pcall(function()
+                BodyAnimMDLarm:SetSkin(handsSkin)
+            end)
+        end
+
+        if handsBgChanged or handsChanged then
             local handBodygroups = SafeGetBodyGroups(handsEnt)
             if handBodygroups then
                 for num, _ in pairs(handBodygroups) do
@@ -574,53 +625,48 @@ hook.Add("Think", "Beatrun_InstantModelUpdate", function()
                     end)
                 end
             end
+        end
+    end
 
+    if modelChanged and playermodelbones then
+        for _, v in ipairs(playermodelbones) do
+            local b = BodyAnimMDL:LookupBone(v)
+            if b then
+                pcall(function()
+                    BodyAnimMDL:ManipulateBoneScale(b, vector_origin)
+                end)
+            end
+        end
+    end
+
+    local bs = GetConVar("Beatrun_BodyScale"):GetFloat()
+    local av = Vector(bs, bs, bs)
+    for i = 0, BodyAnimMDL:GetBoneCount() - 1 do
+        local bonename = BodyAnimMDL:GetBoneName(i)
+        if bonename and not armbones[bonename] then
             pcall(function()
-                BodyAnimMDLarm:SetSkin(handsEnt:GetSkin())
+                BodyAnimMDL:ManipulateBoneScale(i, av)
             end)
         end
+    end
 
-        if playermodelbones then
-			for _, v in ipairs(playermodelbones) do
-				local b = BodyAnimMDL:LookupBone(v)
-
-				if b then
-					pcall(function()
-						BodyAnimMDL:ManipulateBoneScale(b, vector_origin)
-					end)
-				end
-			end
-		end
-
-        local bs = GetConVar("Beatrun_BodyScale"):GetFloat()
-        local av = Vector(bs, bs, bs)
-        for i = 0, BodyAnimMDL:GetBoneCount() - 1 do
-            local bonename = BodyAnimMDL:GetBoneName(i)
-            if bonename and not armbones[bonename] then
-                pcall(function()
-                    BodyAnimMDL:ManipulateBoneScale(i, av)
-                end)
-            end
+    local as = GetConVar("Beatrun_ArmBodyScale"):GetFloat()
+    local aav = Vector(as, as, as)
+    if IsValid(BodyAnimMDLarm) then
+        for i = 0, BodyAnimMDLarm:GetBoneCount() - 1 do
+            pcall(function()
+                BodyAnimMDLarm:ManipulateBoneScale(i, aav)
+            end)
         end
+    end
 
-        local as = GetConVar("Beatrun_ArmBodyScale"):GetFloat()
-        local aav = Vector(as, as, as)
-        if IsValid(BodyAnimMDLarm) then
-            for i = 0, BodyAnimMDLarm:GetBoneCount() - 1 do
-                pcall(function()
-                    BodyAnimMDLarm:ManipulateBoneScale(i, aav)
-                end)
-            end
-        end
-
+    pcall(function()
+        BodyAnimMDL:InvalidateBoneCache()
+    end)
+    if IsValid(BodyAnimMDLarm) then
         pcall(function()
-            BodyAnimMDL:InvalidateBoneCache()
+            BodyAnimMDLarm:InvalidateBoneCache()
         end)
-        if IsValid(BodyAnimMDLarm) then
-            pcall(function()
-                BodyAnimMDLarm:InvalidateBoneCache()
-            end)
-        end
     end
 end)
 

--- a/gamemodes/beatrun/gamemode/player_class/player_beatrun.lua
+++ b/gamemodes/beatrun/gamemode/player_class/player_beatrun.lua
@@ -139,26 +139,26 @@ function PLAYER:Loadout()
 end
 
 function PLAYER:SetModel()
-    BaseClass.SetModel(self)
+	BaseClass.SetModel(self)
 
-    local skin = self.Player:GetInfoNum("cl_playerskin", 0)
-    self.Player:SetSkin(skin)
+	local skin = self.Player:GetInfoNum("cl_playerskin", 0)
+	self.Player:SetSkin(skin)
 
-    local groups = self.Player:GetInfo("cl_playerbodygroups")
+	local groups = self.Player:GetInfo("cl_playerbodygroups")
 
-    if groups == nil then
-        groups = ""
-    end
+	if groups == nil then
+		groups = ""
+	end
 
-    local groups = string.Explode(" ", groups)
+	local groups = string.Explode(" ", groups)
 
-    local numBodyGroups = 0
-    local ok, result = pcall(self.Player.GetNumBodyGroups, self.Player)
-    if ok then numBodyGroups = result or 0 end
+	local numBodyGroups = 0
+	local ok, result = pcall(self.Player.GetNumBodyGroups, self.Player)
+	if ok then numBodyGroups = result or 0 end
 
-    for k = 0, numBodyGroups - 1 do
-        self.Player:SetBodygroup(k, tonumber(groups[k + 1]) or 0)
-    end
+	for k = 0, numBodyGroups - 1 do
+		self.Player:SetBodygroup(k, tonumber(groups[k + 1]) or 0)
+	end
 end
 
 if SERVER then
@@ -461,31 +461,30 @@ hook.Add("PlayerSpawn", "ResetStateTransition", function(ply, transition)
 end)
 
 if SERVER then
-    local LastModels = {}
+	local LastModels = {}
 
-    hook.Add("Think", "BeatrunCheckPlayerModelChange", function()
-        for _, ply in ipairs(player.GetAll()) do
-            if not IsValid(ply) then continue end
+	hook.Add("Think", "BeatrunCheckPlayerModelChange", function()
+		for _, ply in ipairs(player.GetAll()) do
+			if not IsValid(ply) then continue end
 
-            local mdl = ply:GetModel() or ""
-            local clModel = ply:GetInfo("cl_playermodel") or ""
-            if LastModels[ply] == nil then
-                LastModels[ply] = mdl
-                continue
-            end
+			local mdl = ply:GetModel() or ""
+			if LastModels[ply] == nil then
+				LastModels[ply] = mdl
+				continue
+			end
 
-            if mdl ~= LastModels[ply] then
-                LastModels[ply] = mdl
+			if mdl ~= LastModels[ply] then
+				LastModels[ply] = mdl
 
-                timer.Simple(0, function()
-                    if not IsValid(ply) then return end
+				timer.Simple(0, function()
+					if not IsValid(ply) then return end
 
-                    player_manager.RunClass(ply, "SetModel")
-                    ply:SetupHands()
-                end)
-            end
-        end
-    end)
+					player_manager.RunClass(ply, "SetModel")
+					ply:SetupHands()
+				end)
+			end
+		end
+	end)
 end
 
 local lastCheckedModel = ""
@@ -496,178 +495,178 @@ local lastCheckedHandsSkin = 0
 local lastCheckedHandsBodygroups = ""
 
 local function SafeGetNumBodyGroups(ent)
-    if not IsValid(ent) then return 0 end
-    local ok, result = pcall(ent.GetNumBodyGroups, ent)
-    if ok and isnumber(result) then return result end
-    return 0
+	if not IsValid(ent) then return 0 end
+	local ok, result = pcall(ent.GetNumBodyGroups, ent)
+	if ok and isnumber(result) then return result end
+	return 0
 end
 
 local function SafeGetBodyGroups(ent)
-    if not IsValid(ent) then return nil end
-    local ok, result = pcall(ent.GetBodyGroups, ent)
-    if ok and istable(result) then return result end
-    return nil
+	if not IsValid(ent) then return nil end
+	local ok, result = pcall(ent.GetBodyGroups, ent)
+	if ok and istable(result) then return result end
+	return nil
 end
 
 local function GetBodygroupsString(ent)
-    if not IsValid(ent) then return "" end
-    local num = SafeGetNumBodyGroups(ent)
-    if num <= 0 then return "" end
-    
-    local parts = {}
-    for i = 0, num - 1 do
-        local ok, bg = pcall(ent.GetBodygroup, ent, i)
-        table.insert(parts, tostring(ok and bg or 0))
-    end
-    return table.concat(parts, ",")
+	if not IsValid(ent) then return "" end
+	local num = SafeGetNumBodyGroups(ent)
+	if num <= 0 then return "" end
+	
+	local parts = {}
+	for i = 0, num - 1 do
+		local ok, bg = pcall(ent.GetBodygroup, ent, i)
+		table.insert(parts, tostring(ok and bg or 0))
+	end
+	return table.concat(parts, ",")
 end
 
 hook.Add("Think", "Beatrun_InstantModelUpdate", function()
-    if not IsValid(BodyAnim) then return end
-    if not IsValid(BodyAnimMDL) then return end
+	if not IsValid(BodyAnim) then return end
+	if not IsValid(BodyAnimMDL) then return end
 
-    local ply = LocalPlayer()
-    if not IsValid(ply) then return end
+	local ply = LocalPlayer()
+	if not IsValid(ply) then return end
 
-    local mdl = ply:GetModel() or ""
-    local handsEnt = ply:GetHands()
-    local hands = IsValid(handsEnt) and handsEnt:GetModel() or ""
-    local skin = ply:GetSkin() or 0
-    local bodygroups = GetBodygroupsString(ply)
-    local handsSkin = IsValid(handsEnt) and handsEnt:GetSkin() or 0
-    local handsBodygroups = GetBodygroupsString(handsEnt)
+	local mdl = ply:GetModel() or ""
+	local handsEnt = ply:GetHands()
+	local hands = IsValid(handsEnt) and handsEnt:GetModel() or ""
+	local skin = ply:GetSkin() or 0
+	local bodygroups = GetBodygroupsString(ply)
+	local handsSkin = IsValid(handsEnt) and handsEnt:GetSkin() or 0
+	local handsBodygroups = GetBodygroupsString(handsEnt)
 
-    if mdl == "" then return end
+	if mdl == "" then return end
 
-    local modelChanged = mdl ~= lastCheckedModel
-    local handsChanged = hands ~= lastCheckedHands
-    local skinChanged = skin ~= lastCheckedSkin
-    local bgChanged = bodygroups ~= lastCheckedBodygroups
-    local handsSkinChanged = handsSkin ~= lastCheckedHandsSkin
-    local handsBgChanged = handsBodygroups ~= lastCheckedHandsBodygroups
+	local modelChanged = mdl ~= lastCheckedModel
+	local handsChanged = hands ~= lastCheckedHands
+	local skinChanged = skin ~= lastCheckedSkin
+	local bgChanged = bodygroups ~= lastCheckedBodygroups
+	local handsSkinChanged = handsSkin ~= lastCheckedHandsSkin
+	local handsBgChanged = handsBodygroups ~= lastCheckedHandsBodygroups
 
-    if not modelChanged and not handsChanged and not skinChanged and not bgChanged and not handsSkinChanged and not handsBgChanged then
-        return
-    end
+	if not modelChanged and not handsChanged and not skinChanged and not bgChanged and not handsSkinChanged and not handsBgChanged then
+		return
+	end
 
-    lastCheckedModel = mdl
-    lastCheckedHands = hands
-    lastCheckedSkin = skin
-    lastCheckedBodygroups = bodygroups
-    lastCheckedHandsSkin = handsSkin
-    lastCheckedHandsBodygroups = handsBodygroups
+	lastCheckedModel = mdl
+	lastCheckedHands = hands
+	lastCheckedSkin = skin
+	lastCheckedBodygroups = bodygroups
+	lastCheckedHandsSkin = handsSkin
+	lastCheckedHandsBodygroups = handsBodygroups
 
-    if modelChanged then
-        local currentMdl = BodyAnimMDL:GetModel() or ""
-        if currentMdl ~= mdl then
-            local ok = pcall(function()
-                BodyAnimMDL:SetModel(mdl)
-                BodyAnimMDL:SnatchModelInstance(ply)
-            end)
-            if not ok then
-                lastCheckedModel = ""
-                return
-            end
-        end
-    end
+	if modelChanged then
+		local currentMdl = BodyAnimMDL:GetModel() or ""
+		if currentMdl ~= mdl then
+			local ok = pcall(function()
+				BodyAnimMDL:SetModel(mdl)
+				BodyAnimMDL:SnatchModelInstance(ply)
+			end)
+			if not ok then
+				lastCheckedModel = ""
+				return
+			end
+		end
+	end
 
-    if skinChanged or modelChanged then
-        pcall(function()
-            BodyAnimMDL:SetSkin(skin)
-        end)
-    end
+	if skinChanged or modelChanged then
+		pcall(function()
+			BodyAnimMDL:SetSkin(skin)
+		end)
+	end
 
-    if bgChanged or modelChanged then
-        local bodygroupsTable = SafeGetBodyGroups(ply)
-        if bodygroupsTable then
-            for num, _ in pairs(bodygroupsTable) do
-                local bgValue = 0
-                pcall(function()
-                    bgValue = ply:GetBodygroup(num - 1)
-                end)
-                pcall(function()
-                    BodyAnimMDL:SetBodygroup(num - 1, bgValue)
-                end)
-            end
-        end
-    end
+	if bgChanged or modelChanged then
+		local bodygroupsTable = SafeGetBodyGroups(ply)
+		if bodygroupsTable then
+			for num, _ in pairs(bodygroupsTable) do
+				local bgValue = 0
+				pcall(function()
+					bgValue = ply:GetBodygroup(num - 1)
+				end)
+				pcall(function()
+					BodyAnimMDL:SetBodygroup(num - 1, bgValue)
+				end)
+			end
+		end
+	end
 
-    if IsValid(BodyAnimMDLarm) and hands ~= "" then
-        if handsChanged then
-            local currentHandsMdl = BodyAnimMDLarm:GetModel() or ""
-            if currentHandsMdl ~= hands then
-                local ok = pcall(function()
-                    BodyAnimMDLarm:SetModel(hands)
-                end)
-                if not ok then
-                    lastCheckedHands = ""
-                    return
-                end
-            end
-        end
+	if IsValid(BodyAnimMDLarm) and hands ~= "" then
+		if handsChanged then
+			local currentHandsMdl = BodyAnimMDLarm:GetModel() or ""
+			if currentHandsMdl ~= hands then
+				local ok = pcall(function()
+					BodyAnimMDLarm:SetModel(hands)
+				end)
+				if not ok then
+					lastCheckedHands = ""
+					return
+				end
+			end
+		end
 
-        if handsSkinChanged or handsChanged then
-            pcall(function()
-                BodyAnimMDLarm:SetSkin(handsSkin)
-            end)
-        end
+		if handsSkinChanged or handsChanged then
+			pcall(function()
+				BodyAnimMDLarm:SetSkin(handsSkin)
+			end)
+		end
 
-        if handsBgChanged or handsChanged then
-            local handBodygroups = SafeGetBodyGroups(handsEnt)
-            if handBodygroups then
-                for num, _ in pairs(handBodygroups) do
-                    local bgValue = 0
-                    pcall(function()
-                        bgValue = handsEnt:GetBodygroup(num - 1)
-                    end)
-                    pcall(function()
-                        BodyAnimMDLarm:SetBodygroup(num - 1, bgValue)
-                    end)
-                end
-            end
-        end
-    end
+		if handsBgChanged or handsChanged then
+			local handBodygroups = SafeGetBodyGroups(handsEnt)
+			if handBodygroups then
+				for num, _ in pairs(handBodygroups) do
+					local bgValue = 0
+					pcall(function()
+						bgValue = handsEnt:GetBodygroup(num - 1)
+					end)
+					pcall(function()
+						BodyAnimMDLarm:SetBodygroup(num - 1, bgValue)
+					end)
+				end
+			end
+		end
+	end
 
-    if modelChanged and playermodelbones then
-        for _, v in ipairs(playermodelbones) do
-            local b = BodyAnimMDL:LookupBone(v)
-            if b then
-                pcall(function()
-                    BodyAnimMDL:ManipulateBoneScale(b, vector_origin)
-                end)
-            end
-        end
-    end
+	if modelChanged and playermodelbones then
+		for _, v in ipairs(playermodelbones) do
+			local b = BodyAnimMDL:LookupBone(v)
+			if b then
+				pcall(function()
+					BodyAnimMDL:ManipulateBoneScale(b, vector_origin)
+				end)
+			end
+		end
+	end
 
-    local bs = GetConVar("Beatrun_BodyScale"):GetFloat()
-    local av = Vector(bs, bs, bs)
-    for i = 0, BodyAnimMDL:GetBoneCount() - 1 do
-        local bonename = BodyAnimMDL:GetBoneName(i)
-        if bonename and not armbones[bonename] then
-            pcall(function()
-                BodyAnimMDL:ManipulateBoneScale(i, av)
-            end)
-        end
-    end
+	local bs = GetConVar("Beatrun_BodyScale"):GetFloat()
+	local av = Vector(bs, bs, bs)
+	for i = 0, BodyAnimMDL:GetBoneCount() - 1 do
+		local bonename = BodyAnimMDL:GetBoneName(i)
+		if bonename and not armbones[bonename] then
+			pcall(function()
+				BodyAnimMDL:ManipulateBoneScale(i, av)
+			end)
+		end
+	end
 
-    local as = GetConVar("Beatrun_ArmBodyScale"):GetFloat()
-    local aav = Vector(as, as, as)
-    if IsValid(BodyAnimMDLarm) then
-        for i = 0, BodyAnimMDLarm:GetBoneCount() - 1 do
-            pcall(function()
-                BodyAnimMDLarm:ManipulateBoneScale(i, aav)
-            end)
-        end
-    end
+	local as = GetConVar("Beatrun_ArmBodyScale"):GetFloat()
+	local aav = Vector(as, as, as)
+	if IsValid(BodyAnimMDLarm) then
+		for i = 0, BodyAnimMDLarm:GetBoneCount() - 1 do
+			pcall(function()
+				BodyAnimMDLarm:ManipulateBoneScale(i, aav)
+			end)
+		end
+	end
 
-    pcall(function()
-        BodyAnimMDL:InvalidateBoneCache()
-    end)
-    if IsValid(BodyAnimMDLarm) then
-        pcall(function()
-            BodyAnimMDLarm:InvalidateBoneCache()
-        end)
-    end
+	pcall(function()
+		BodyAnimMDL:InvalidateBoneCache()
+	end)
+	if IsValid(BodyAnimMDLarm) then
+		pcall(function()
+			BodyAnimMDLarm:InvalidateBoneCache()
+		end)
+	end
 end)
 
 player_manager.RegisterClass("player_beatrun", PLAYER, "player_default")


### PR DESCRIPTION
Updates the Beatrun viewmodel when applying skin through Enhanced PlayerModel Selector. No need to respawn or "EvadeRoll" anymore.
Also updates body groups.

Showcase:

https://github.com/user-attachments/assets/e87ac96f-62ee-4a19-919d-be9fab048746

Body groups:

https://github.com/user-attachments/assets/6b06ed32-b4cf-4188-b4de-57bb78d18e76