### PR TITLE
fix: broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,10 +132,10 @@ You can now change animations in the **Tools menu** under the Beatrun category.
 ## Star History
 
 <!-- markdownlint-disable MD033 -->
-<a href="https://www.star-history.com/#JonnyBro/beatrun&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#JonnyBro/beatrun&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=JonnyBro/beatrun&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=JonnyBro/beatrun&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=JonnyBro/beatrun&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=JonnyBro/beatrun&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=JonnyBro/beatrun&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=JonnyBro/beatrun&type=date&legend=top-left" />
  </picture>
 </a>

--- a/README.ru.md
+++ b/README.ru.md
@@ -133,10 +133,10 @@ Beatrun - это **небезызвестный паркур режим для G
 ## Звёздочки
 
 <!-- markdownlint-disable MD033 -->
-<a href="https://www.star-history.com/#JonnyBro/beatrun&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#JonnyBro/beatrun&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=JonnyBro/beatrun&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=JonnyBro/beatrun&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=JonnyBro/beatrun&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=JonnyBro/beatrun&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=JonnyBro/beatrun&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=JonnyBro/beatrun&type=date&legend=top-left" />
  </picture>
 </a>


### PR DESCRIPTION
The star history chart in the README was broken because the current data source is limited by GitHub stargazer API restrictions. This switches the chart to a working alternative so it displays correctly again.

Also updated the Russian README to match.