### PR TITLE
jumpanim.lua animation fixes

### DIFF
--- a/gamemodes/beatrun/gamemode/cl/BodyAnim.lua
+++ b/gamemodes/beatrun/gamemode/cl/BodyAnim.lua
@@ -328,8 +328,8 @@ function CacheLerpBodyAnim()
 				local ModelBoneMatrix = BodyAnim:GetBoneMatrix(bone)
 				ModelBoneMatrix:SetTranslation(ModelBoneMatrix:GetTranslation())
 
-				from[bone] = cachebody[bone]:FastToTable(from[bone]) or from[bone]
 				to[bone] = to[bone] or ModelBoneMatrix:FastToTable(to[bone])
+				from[bone] = cachebody[bone] and cachebody[bone]:FastToTable(from[bone]) or to[bone]
 
 				local bonematrix = this:GetBoneMatrix(bone)
 				bonematrix:SetTranslation(bonematrix:GetTranslation() - pos)

--- a/gamemodes/beatrun/gamemode/cl/JumpAnim.lua
+++ b/gamemodes/beatrun/gamemode/cl/JumpAnim.lua
@@ -1291,14 +1291,6 @@ eventsounds = {
 	}
 }
 
--- Single entry point for addons/forks to register a new body-anim event that plays
--- on its own custom .mdl, without touching the tables above by hand each time.
--- data fields: model (required, "path/relative/to/models" no extension),
--- sequence (defaults to event name), transitionanim (defaults to "jumpair"),
--- transitioncheck(ply) (defaults to "done after one cycle"), sounds (eventsounds entry, optional),
--- speed (BodyAnimSpeed multiplier, optional), onStart(ply)/onFinish(ply) (optional callbacks).
--- Returns a handle: handle.start(ply) fires the event via ParkourEvent, handle.stop(ply) forces
--- an early transition out (same path a natural transitioncheck would take) and fires onFinish.
 CustomAnims = CustomAnims or {}
 
 function RegisterCustomAnim(event, data)
@@ -1651,8 +1643,6 @@ end)
 
 
 local function JumpAnim(event, ply)
-	print("[JumpAnim]", event, "cycle=", BodyAnimCycle, "onground=", ply:OnGround(), "curstring=", BodyAnimString)
-
 	if CatalystCoil:GetBool() and event == "coil" and ply:UsingRH() then
 		eventslut.coil = "jumpcoilcatalyst"
 	else
@@ -1681,9 +1671,6 @@ local function JumpAnim(event, ply)
 			customAnimForEvent.onStart(ply)
 		end
 
-		-- must also check the *previous* BodyAnimString, not just the incoming event - a custom
-		-- anim (e.g. grapple_throw) uses its own .mdl, so transitioning away from one can't reuse
-		-- the existing BodyAnim entity even though the new event itself isn't a custom anim
 		local wasjumpanim = not CustomAnims[event] and not CustomAnims[BodyAnimString] and fbanims[BodyAnimString] and IsValid(BodyAnim)
 
 		if not wasjumpanim then

--- a/gamemodes/beatrun/gamemode/cl/JumpAnim.lua
+++ b/gamemodes/beatrun/gamemode/cl/JumpAnim.lua
@@ -1291,6 +1291,56 @@ eventsounds = {
 	}
 }
 
+-- Single entry point for addons/forks to register a new body-anim event that plays
+-- on its own custom .mdl, without touching the tables above by hand each time.
+-- data fields: model (required, "path/relative/to/models" no extension),
+-- sequence (defaults to event name), transitionanim (defaults to "jumpair"),
+-- transitioncheck(ply) (defaults to "done after one cycle"), sounds (eventsounds entry, optional),
+-- speed (BodyAnimSpeed multiplier, optional), onStart(ply)/onFinish(ply) (optional callbacks).
+-- Returns a handle: handle.start(ply) fires the event via ParkourEvent, handle.stop(ply) forces
+-- an early transition out (same path a natural transitioncheck would take) and fires onFinish.
+CustomAnims = CustomAnims or {}
+
+function RegisterCustomAnim(event, data)
+	fbanims[event] = true
+	events[event] = true
+	eventslut[event] = data.sequence or event
+	transitionanims[event] = data.transitionanim or "jumpair"
+	transitionchecks[event] = data.transitioncheck or function(ply)
+		if BodyAnimCycle >= 1 then return true end
+	end
+
+	if data.sounds then
+		eventsounds[event] = data.sounds
+	end
+
+	if data.speed then
+		customspeed[event] = data.speed
+	end
+
+	CustomAnims[event] = data
+
+	local handle = {}
+
+	function handle.start(ply)
+		ParkourEvent(event, ply or LocalPlayer(), true)
+	end
+
+	function handle.stop(ply)
+		ply = ply or LocalPlayer()
+
+		if BodyAnimString ~= event or not IsValid(BodyAnim) then return end
+
+		BodyAnim:SetSequence(transitionanims[event])
+
+		if data.onFinish then
+			data.onFinish(ply)
+		end
+	end
+
+	return handle
+end
+
 local CharaName = "Faith"
 
 local function BodyEventSounds(anim)
@@ -1601,6 +1651,8 @@ end)
 
 
 local function JumpAnim(event, ply)
+	print("[JumpAnim]", event, "cycle=", BodyAnimCycle, "onground=", ply:OnGround(), "curstring=", BodyAnimString)
+
 	if CatalystCoil:GetBool() and event == "coil" and ply:UsingRH() then
 		eventslut.coil = "jumpcoilcatalyst"
 	else
@@ -1623,7 +1675,16 @@ local function JumpAnim(event, ply)
 	-]]
 
 	if events[event] then
-		local wasjumpanim = fbanims[BodyAnimString] and IsValid(BodyAnim)
+		local customAnimForEvent = CustomAnims[event]
+
+		if customAnimForEvent and customAnimForEvent.onStart then
+			customAnimForEvent.onStart(ply)
+		end
+
+		-- must also check the *previous* BodyAnimString, not just the incoming event - a custom
+		-- anim (e.g. grapple_throw) uses its own .mdl, so transitioning away from one can't reuse
+		-- the existing BodyAnim entity even though the new event itself isn't a custom anim
+		local wasjumpanim = not CustomAnims[event] and not CustomAnims[BodyAnimString] and fbanims[BodyAnimString] and IsValid(BodyAnim)
 
 		if not wasjumpanim then
 			RemoveBodyAnim()
@@ -1685,7 +1746,11 @@ end
 function CheckAnims()
 	RemoveBodyAnim()
 
-	if AnimSet:GetInt() == 0 then
+	local customAnim = CustomAnims[BodyAnimString]
+
+	if customAnim then
+		animtable.animmodelstring = customAnim.model
+	elseif AnimSet:GetInt() == 0 then
 		animtable.animmodelstring = "new_climbanim"
 	else
 		animtable.animmodelstring = "old_climbanim"
@@ -2033,6 +2098,12 @@ local function JumpThink()
 			local check = transitionchecks[BodyAnimString]
 
 			if check and check(ply) or not check and BodyAnimCycle >= 0.9 and transitionanims[BodyAnimString] then
+				local customAnimForCurrent = CustomAnims[BodyAnimString]
+
+				if customAnimForCurrent and customAnimForCurrent.onFinish then
+					customAnimForCurrent.onFinish(ply)
+				end
+
 				BodyAnim:SetSequence(transitionanims[BodyAnimString])
 			end
 


### PR DESCRIPTION
this fork needs to be in the game because it allows mods to externally add animations and run them with `ParkourEvent("...", ply, true)` and it will work.

example:
```lua
RegisterCustomAnim("grapple_throw", {
   model = "beatrun/gears/grappler/anims/grappler_arms"
})
```

and in action:
```lua
-- some code above to confirm running this
ParkourEvent("grapple_throw", ply, true)
```
